### PR TITLE
Allow fractional crypto quantities

### DIFF
--- a/src/components/portfolio/AddPositionForm.tsx
+++ b/src/components/portfolio/AddPositionForm.tsx
@@ -175,7 +175,7 @@ export default function AddPositionForm({ portfolioId, onSuccess, onCancel, sugg
               onChange={(e) => setQuantity(e.target.value)}
               required
               min="0"
-              step="0.000001"
+              step="0.00000001"
               className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-gray-900"
               placeholder="100"
             />

--- a/src/components/portfolio/ClosePositionForm.tsx
+++ b/src/components/portfolio/ClosePositionForm.tsx
@@ -36,7 +36,7 @@ export default function ClosePositionForm({ position, onSuccess, onCancel }: Clo
     }
     
     if (quantityNum <= 0 || quantityNum > position.quantity) {
-      setError(`Quantity must be between 1 and ${position.quantity}`);
+      setError(`Quantity must be greater than 0 and no more than ${position.quantity}`);
       return;
     }
 
@@ -108,9 +108,9 @@ export default function ClosePositionForm({ position, onSuccess, onCancel }: Clo
                   value={quantity}
                   onChange={(e) => setQuantity(e.target.value)}
                   required
-                  min="1"
+                  min="0.00000001"
                   max={position.quantity}
-                  step="0.000001"
+                  step="0.00000001"
                   className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-gray-900"
                   placeholder={position.quantity.toString()}
                 />


### PR DESCRIPTION
## Summary
- allow fractional quantities by using 8 decimal places in forms
- relax quantity validation when closing positions

## Testing
- `npm test` *(fails: `playwright: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687a54759e6c832e949684baace96eb1