### PR TITLE
Nest portfolio data

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,12 +5,14 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import CreatePortfolioForm from '@/components/portfolio/CreatePortfolioForm';
 import PortfolioList from '@/components/portfolio/PortfolioList';
+import { migrateUserData } from '@/lib/firestore';
 
 export default function Dashboard() {
   const { user, loading, logout } = useAuth();
   const router = useRouter();
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [portfolioCreated, setPortfolioCreated] = useState(false);
+  const [migrating, setMigrating] = useState(false);
 
   useEffect(() => {
     if (!loading && !user) {
@@ -21,6 +23,20 @@ export default function Dashboard() {
   const handlePortfolioCreated = (portfolioId: string) => {
     setShowCreateForm(false);
     setPortfolioCreated(!portfolioCreated);
+  };
+
+  const handleMigrate = async () => {
+    if (!user) return;
+    setMigrating(true);
+    try {
+      await migrateUserData(user.uid);
+      alert('Migration complete');
+    } catch (err) {
+      console.error('Migration failed', err);
+      alert('Migration failed');
+    } finally {
+      setMigrating(false);
+    }
   };
 
   if (loading) {
@@ -54,12 +70,20 @@ export default function Dashboard() {
         <div className="mb-8">
           <div className="flex justify-between items-center mb-4">
             <h2 className="text-2xl font-bold text-gray-900">Your Portfolios</h2>
-            <button
-              onClick={() => setShowCreateForm(!showCreateForm)}
-              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md font-medium transition-colors"
-            >
-              {showCreateForm ? 'Cancel' : 'Create Portfolio'}
-            </button>
+            <div className="flex space-x-2">
+              <button
+                onClick={() => setShowCreateForm(!showCreateForm)}
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md font-medium transition-colors"
+              >
+                {showCreateForm ? 'Cancel' : 'Create Portfolio'}
+              </button>
+              <button
+                onClick={handleMigrate}
+                className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md font-medium transition-colors"
+              >
+                {migrating ? 'Migrating...' : 'Migrate Data'}
+              </button>
+            </div>
           </div>
 
           {showCreateForm && (

--- a/src/app/portfolio/[id]/page.tsx
+++ b/src/app/portfolio/[id]/page.tsx
@@ -84,9 +84,9 @@ export default function PortfolioPage() {
 
   const handleDeletePosition = async (positionId: string) => {
     if (!confirm('Are you sure you want to delete this position?')) return;
-    
+
     try {
-      await deletePosition(positionId);
+      await deletePosition(params.id as string, positionId);
       // Refresh portfolio data after deleting position
       refreshPortfolioData();
     } catch (err) {

--- a/src/components/portfolio/ClosePositionForm.tsx
+++ b/src/components/portfolio/ClosePositionForm.tsx
@@ -49,7 +49,7 @@ export default function ClosePositionForm({ position, onSuccess, onCancel }: Clo
     setError('');
 
     try {
-      await closePosition(position.id, priceNum, quantityNum, feesNum);
+      await closePosition(position.portfolioId, position.id, priceNum, quantityNum, feesNum);
       
       if (onSuccess) {
         onSuccess();

--- a/src/components/portfolio/SuggestedTrades.tsx
+++ b/src/components/portfolio/SuggestedTrades.tsx
@@ -161,7 +161,7 @@ export default function SuggestedTrades({ portfolio, onTradeConverted }: Suggest
     
     try {
       // Update suggested trade status to converted
-      await updateSuggestedTradeStatus(tradeToConvert.id, 'converted');
+      await updateSuggestedTradeStatus(portfolio.id, tradeToConvert.id, 'converted');
       
       // Close the form
       setShowAddPositionForm(false);


### PR DESCRIPTION
## Summary
- use portfolio subcollections for positions and suggested trades
- adjust paths and signatures for updating and deleting
- store trades under each portfolio in Python service
- add helper to migrate existing data
- button on dashboard triggers migration

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ab8cec2a8832ea0fb1aff9410b339