### PR TITLE
Add cloud task queuing function for portfolio performance

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -26,6 +26,7 @@ The following Firebase functions are deployed:
 | `dismiss_suggested_trade` | `/dismiss_suggested_trade` | `POST` |
 | `lookup_symbol` | `/lookup_symbol` | `POST` |
 | `get_portfolio_advice` | `/get_portfolio_advice` | `POST` |
+| `request_portfolio_performance` | `/request_portfolio_performance` | `POST` |
 
 All endpoints expect a Firebase Auth bearer token and return JSON responses.
 

--- a/functions/main.py
+++ b/functions/main.py
@@ -6,6 +6,7 @@ from google.cloud import firestore
 from datetime import datetime
 import os
 
+
 # Heavy imports moved inside functions to avoid initialization timeout
 # from stock_service import StockPriceService
 # from auth_utils import AuthUtils, AuthError  
@@ -639,5 +640,88 @@ def get_portfolio_advice(req):
         response = {
             'error': 'Internal Server Error',
             'message': f'Failed to generate portfolio advice: {str(e)}'
+        }
+        return (json.dumps(response), 500, headers)
+
+
+@https_fn.on_request(memory=options.MemoryOption.GB_1)
+def request_portfolio_performance(req):
+    """Queue a Cloud Task to generate portfolio performance and advice."""
+    cors_result = handle_cors(req, ['POST'])
+    if cors_result.must_return:
+        return cors_result.result
+    headers = cors_result.headers
+
+    try:
+        request_data = parse_json_body(req)
+        portfolio_id = request_data.get('portfolio_id')
+        if not portfolio_id:
+            response = {
+                'error': 'Bad Request',
+                'message': 'portfolio_id is required in request body'
+            }
+            return (json.dumps(response), 400, headers)
+
+        from google.cloud import tasks_v2
+
+        project = os.getenv('GCP_PROJECT') or os.getenv('PROJECT_ID') or os.getenv('GCLOUD_PROJECT')
+        location = os.getenv('CLOUD_TASKS_LOCATION', 'us-central1')
+        queue = os.getenv('CLOUD_TASKS_QUEUE', 'portfolio-tasks')
+
+        if not project:
+            response = {
+                'error': 'Server configuration error',
+                'message': 'Project ID environment variable is not set'
+            }
+            return (json.dumps(response), 500, headers)
+
+        token = os.getenv('CLOUD_TASKS_BEARER_TOKEN')
+        if not token:
+            response = {
+                'error': 'Server configuration error',
+                'message': 'CLOUD_TASKS_BEARER_TOKEN is not set'
+            }
+            return (json.dumps(response), 500, headers)
+
+        function_base = os.getenv('CLOUD_FUNCTIONS_BASE_URL', f'https://{location}-{project}.cloudfunctions.net')
+        url = f'{function_base}/get_portfolio_advice'
+
+        payload = json.dumps({'portfolio_id': portfolio_id}).encode()
+
+        client = tasks_v2.CloudTasksClient()
+        parent = client.queue_path(project, location, queue)
+
+        task = {
+            'http_request': {
+                'http_method': tasks_v2.HttpMethod.POST,
+                'url': url,
+                'headers': {
+                    'Content-Type': 'application/json',
+                    'Authorization': f'Bearer {token}'
+                },
+                'body': payload
+            }
+        }
+
+        client.create_task(request={'parent': parent, 'task': task})
+
+        response = {
+            'queued': True,
+            'portfolio_id': portfolio_id,
+            'timestamp': datetime.now().isoformat()
+        }
+        return (json.dumps(response), 200, headers)
+
+    except ValueError as e:
+        response = {
+            'error': 'Bad Request',
+            'message': str(e)
+        }
+        return (json.dumps(response), 400, headers)
+
+    except Exception as e:
+        response = {
+            'error': 'Internal Server Error',
+            'message': f'Failed to create Cloud Task: {str(e)}'
         }
         return (json.dumps(response), 500, headers)

--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -10,3 +10,4 @@ openai>=1.0.0
 python-dotenv>=1.0.0
 pydantic>=2.0.0
 google-cloud-logging>=3.2.0
+google-cloud-tasks>=2.12.0


### PR DESCRIPTION
## Summary
- queue Cloud Task to invoke portfolio advice generation
- document new `request_portfolio_performance` endpoint
- add Cloud Tasks dependency

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ad93111d0832ea593ce5732ad184a