### PR TITLE
Add real-time advice display

### DIFF
--- a/src/app/portfolio/[id]/page.tsx
+++ b/src/app/portfolio/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
-import { getPortfolio, getPositions, getTrades, deletePosition, deleteTrade, recalculateCashBalance } from '@/lib/firestore';
+import { getPortfolio, getPositions, getTrades, deletePosition, deleteTrade, recalculateCashBalance, subscribePortfolio } from '@/lib/firestore';
 import { Portfolio, Position, Trade } from '@/types';
 import { formatCurrency, formatPercentage } from '@/lib/currency';
 import { useStockPrices, PositionWithCurrentPrice } from '@/hooks/useStockPrices';
@@ -95,6 +95,16 @@ export default function PortfolioPage() {
 
     fetchPortfolio();
   }, [user, params.id]);
+
+  useEffect(() => {
+    if (!params.id) return;
+    const unsubscribe = subscribePortfolio(params.id as string, (updated) => {
+      if (updated) {
+        setPortfolio(updated);
+      }
+    });
+    return () => unsubscribe();
+  }, [params.id]);
 
   const handleDeletePosition = async (positionId: string) => {
     if (!confirm('Are you sure you want to delete this position?')) return;
@@ -405,6 +415,12 @@ export default function PortfolioPage() {
                 <div className="mt-3 p-3 bg-blue-50 rounded-lg">
                   <h4 className="text-sm font-medium text-blue-900 mb-1">Investment Goal</h4>
                   <p className="text-sm text-blue-800">{portfolio.goal}</p>
+                </div>
+              )}
+              {portfolio.advice && (
+                <div className="mt-3 p-3 bg-green-50 rounded-lg">
+                  <h4 className="text-sm font-medium text-green-900 mb-1">Portfolio Advice</h4>
+                  <p className="text-sm text-green-800 whitespace-pre-line">{portfolio.advice}</p>
                 </div>
               )}
             </div>

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -25,6 +25,7 @@ const convertFirestoreToPortfolio = (id: string, data: Record<string, unknown>):
     id,
     ...data,
     initialCashBalance: data.initialCashBalance as number,
+    advice: data.advice as string | undefined,
     createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : new Date(data.createdAt as string),
     updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toDate() : new Date(data.updatedAt as string),
   } as Portfolio;
@@ -620,6 +621,25 @@ export const subscribeSuggestedTrades = (
     });
   } catch (error) {
     console.error('Error setting up suggested trades listener:', error);
+    throw error;
+  }
+};
+
+export const subscribePortfolio = (
+  portfolioId: string,
+  callback: (portfolio: Portfolio | null) => void
+): Unsubscribe => {
+  try {
+    const portfolioRef = doc(db, 'portfolios', portfolioId);
+    return onSnapshot(portfolioRef, (snapshot) => {
+      if (snapshot.exists()) {
+        callback(convertFirestoreToPortfolio(snapshot.id, snapshot.data()));
+      } else {
+        callback(null);
+      }
+    });
+  } catch (error) {
+    console.error('Error setting up portfolio listener:', error);
     throw error;
   }
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,7 @@ export interface Portfolio {
   name?: string;
   description?: string;
   goal?: string;
+  advice?: string;
   isPublic: boolean;
   isBotPortfolio?: boolean;
   cashBalance: number;


### PR DESCRIPTION
## Summary
- include `advice` on Portfolio type
- expose firestore `subscribePortfolio` listener
- subscribe to portfolio changes on the Portfolio page and render advice if present

## Testing
- `npm test` *(fails: `playwright: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687ad979246c832eb9b1c627e5043b3b