### PR TITLE
Add portfolio advice request feature

### DIFF
--- a/src/app/portfolio/[id]/page.tsx
+++ b/src/app/portfolio/[id]/page.tsx
@@ -10,6 +10,7 @@ import { useStockPrices, PositionWithCurrentPrice } from '@/hooks/useStockPrices
 import AddPositionForm from '@/components/portfolio/AddPositionForm';
 import ClosePositionForm from '@/components/portfolio/ClosePositionForm';
 import SuggestedTrades from '@/components/portfolio/SuggestedTrades';
+import { portfolioApiClient } from '@/lib/portfolio-api-client';
 import Link from 'next/link';
 
 export default function PortfolioPage() {
@@ -24,6 +25,7 @@ export default function PortfolioPage() {
   const [showAddForm, setShowAddForm] = useState(false);
   const [positionToClose, setPositionToClose] = useState<Position | null>(null);
   const [updatingCash, setUpdatingCash] = useState(false);
+  const [requestingAdvice, setRequestingAdvice] = useState(false);
 
   const fetchPositions = async () => {
     if (!params.id) return;
@@ -140,6 +142,19 @@ export default function PortfolioPage() {
       console.error('Failed to recalculate cash balance:', err);
     } finally {
       setUpdatingCash(false);
+    }
+  };
+
+  const handleRequestAdvice = async () => {
+    if (!portfolio) return;
+    setRequestingAdvice(true);
+    try {
+      await portfolioApiClient.requestPortfolioPerformance(portfolio.id);
+    } catch (err) {
+      console.error('Failed to request portfolio advice:', err);
+      alert('Failed to request portfolio advice');
+    } finally {
+      setRequestingAdvice(false);
     }
   };
 
@@ -424,6 +439,13 @@ export default function PortfolioPage() {
                   <p className="text-sm text-blue-800">{portfolio.goal}</p>
                 </div>
               )}
+              <button
+                onClick={handleRequestAdvice}
+                disabled={requestingAdvice}
+                className="mt-3 px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:bg-gray-400 transition-colors text-sm"
+              >
+                {requestingAdvice ? 'Requesting Advice...' : 'Get Portfolio Advice'}
+              </button>
               {portfolio.advice && (
                 <div className="mt-3 p-3 bg-green-50 rounded-lg">
                   <h4 className="text-sm font-medium text-green-900 mb-1">Portfolio Advice</h4>

--- a/src/lib/portfolio-api-client.ts
+++ b/src/lib/portfolio-api-client.ts
@@ -6,6 +6,7 @@ const CONSTRUCT_PORTFOLIO_URL = 'https://construct-portfolio-32rtfol3iq-uc.a.run
 const GET_SUGGESTED_TRADES_URL = 'https://get-suggested-trades-32rtfol3iq-uc.a.run.app';
 const CONVERT_SUGGESTED_TRADE_URL = 'https://convert-suggested-trade-32rtfol3iq-uc.a.run.app';
 const DISMISS_SUGGESTED_TRADE_URL = 'https://dismiss-suggested-trade-32rtfol3iq-uc.a.run.app';
+const REQUEST_PORTFOLIO_PERFORMANCE_URL = 'https://request-portfolio-performance-32rtfol3iq-uc.a.run.app';
 
 export interface ConstructPortfolioRequest {
   portfolio_goal: string;
@@ -53,6 +54,12 @@ export interface DismissSuggestedTradeRequest {
 export interface DismissSuggestedTradeResponse {
   success: boolean;
   message: string;
+}
+
+export interface RequestPortfolioPerformanceResponse {
+  queued: boolean;
+  portfolio_id: string;
+  timestamp: string;
 }
 
 export class PortfolioApiClient {
@@ -209,7 +216,33 @@ export class PortfolioApiClient {
       throw error;
     }
   }
+
+  async requestPortfolioPerformance(portfolioId: string): Promise<RequestPortfolioPerformanceResponse> {
+    try {
+      const token = await this.getAuthToken();
+
+      const response = await fetch(REQUEST_PORTFOLIO_PERFORMANCE_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ portfolio_id: portfolioId })
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || 'Failed to request portfolio advice');
+      }
+
+      return data as RequestPortfolioPerformanceResponse;
+    } catch (error) {
+      console.error('Error requesting portfolio advice:', error);
+      throw error;
+    }
+  }
 }
 
 // Export singleton instance
-export const portfolioApiClient = PortfolioApiClient.getInstance(); 
+export const portfolioApiClient = PortfolioApiClient.getInstance();


### PR DESCRIPTION
## Summary
- enable requesting portfolio advice from portfolio page
- add API client call for `request_portfolio_performance`

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_687add033014832eb2262576fee58091