### PR TITLE
Add Markdown portfolio advice

### DIFF
--- a/functions/portfolio_service.py
+++ b/functions/portfolio_service.py
@@ -266,12 +266,13 @@ class PortfolioService:
                     "system",
                     "You are an experienced investment advisor. "
                     "Use the available tools to fetch up to date stock prices and news "
-                    "before providing advice on a portfolio.",
+                    "before providing advice on a portfolio. "
+                    "Return your final answer formatted in Markdown for display.",
                 ),
                 ("user", "{input}"),
                 (
                     "assistant",
-                    "I'll research the holdings and craft a short analysis.",
+                    "I'll research the holdings and craft a short analysis in Markdown.",
                 ),
                 ("placeholder", "{agent_scratchpad}"),
             ]

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "firebase-admin": "^13.4.0",
     "next": "15.4.1",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "react-markdown": "^9.0.6",
+    "remark-gfm": "^3.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/portfolio/[id]/page.tsx
+++ b/src/app/portfolio/[id]/page.tsx
@@ -10,6 +10,7 @@ import { useStockPrices, PositionWithCurrentPrice } from '@/hooks/useStockPrices
 import AddPositionForm from '@/components/portfolio/AddPositionForm';
 import ClosePositionForm from '@/components/portfolio/ClosePositionForm';
 import SuggestedTrades from '@/components/portfolio/SuggestedTrades';
+import MarkdownViewer from '@/components/MarkdownViewer';
 import { portfolioApiClient } from '@/lib/portfolio-api-client';
 import Link from 'next/link';
 
@@ -439,19 +440,6 @@ export default function PortfolioPage() {
                   <p className="text-sm text-blue-800">{portfolio.goal}</p>
                 </div>
               )}
-              <button
-                onClick={handleRequestAdvice}
-                disabled={requestingAdvice}
-                className="mt-3 px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:bg-gray-400 transition-colors text-sm"
-              >
-                {requestingAdvice ? 'Requesting Advice...' : 'Get Portfolio Advice'}
-              </button>
-              {portfolio.advice && (
-                <div className="mt-3 p-3 bg-green-50 rounded-lg">
-                  <h4 className="text-sm font-medium text-green-900 mb-1">Portfolio Advice</h4>
-                  <p className="text-sm text-green-800 whitespace-pre-line">{portfolio.advice}</p>
-                </div>
-              )}
             </div>
           </div>
         </div>
@@ -627,6 +615,21 @@ export default function PortfolioPage() {
             <h2 className="text-xl font-semibold text-gray-900">Trades</h2>
           </div>
           {renderTradesTable()}
+        </div>
+
+        {/* Portfolio Advice Section */}
+        <div className="bg-white rounded-lg shadow-md p-6 mt-8">
+          <h2 className="text-xl font-semibold text-gray-900 mb-4">Portfolio Advice</h2>
+          <button
+            onClick={handleRequestAdvice}
+            disabled={requestingAdvice}
+            className="mb-4 px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:bg-gray-400 transition-colors text-sm"
+          >
+            {requestingAdvice ? 'Requesting Advice...' : 'Get Portfolio Advice'}
+          </button>
+          {portfolio.advice && (
+            <MarkdownViewer content={portfolio.advice} />
+          )}
         </div>
 
         {/* Portfolio Info */}

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+interface MarkdownViewerProps {
+  content: string;
+  maxLines?: number;
+}
+
+export default function MarkdownViewer({ content, maxLines = 4 }: MarkdownViewerProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const lines = content.split('\n');
+  const shouldTruncate = lines.length > maxLines;
+  const displayContent = expanded || !shouldTruncate ? content : lines.slice(0, maxLines).join('\n');
+
+  return (
+    <div>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} className="prose prose-sm">
+        {displayContent}
+      </ReactMarkdown>
+      {shouldTruncate && !expanded && (
+        <button onClick={() => setExpanded(true)} className="text-blue-600 mt-2 text-sm">
+          Show more
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- return markdown from the AI advice generator
- display portfolio advice after the trade list
- render advice using a new MarkdownViewer component
- show a "Show more" button when the advice is long
- install react-markdown and remark-gfm

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npx playwright test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687adf2d090c832eafae3f2bb811fec5