### PR TITLE
Async suggested trades generation

### DIFF
--- a/functions/portfolio_service.py
+++ b/functions/portfolio_service.py
@@ -5,7 +5,7 @@ Provides AI-powered portfolio recommendations using multiple financial data sour
 
 import os
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, Any, List
 from langchain_openai import ChatOpenAI
 from langchain.agents import create_openai_tools_agent, AgentExecutor
@@ -448,7 +448,11 @@ class PortfolioService:
                     'created_at': datetime.now(),  # Keep for backward compatibility
                     'updatedAt': datetime.now(),
                     'source': 'ai_portfolio_construction',
-                    'portfolio_recommendation_id': portfolio_recommendation.get('portfolio_summary', {}).get('date_created', datetime.now().isoformat())
+                    'portfolio_recommendation_id': portfolio_recommendation.get(
+                        'portfolio_summary', {}
+                    ).get('date_created', datetime.now().isoformat()),
+                    'expiresAt': datetime.now() + timedelta(days=7),
+                    'expires_at': datetime.now() + timedelta(days=7),
                 }
                 
                 # Validate all fields are not None/undefined before saving
@@ -564,6 +568,7 @@ class PortfolioService:
                 .document(str(portfolio_id))
                 .collection('suggestedTrades')
                 .where('userId', '==', user_id)
+                .where('expires_at', '>', datetime.now())
             )
             
             # Add status filter if provided

--- a/src/components/portfolio/SuggestedTrades.tsx
+++ b/src/components/portfolio/SuggestedTrades.tsx
@@ -108,40 +108,13 @@ export default function SuggestedTrades({ portfolio, onTradeConverted }: Suggest
         await new Promise(resolve => setTimeout(resolve, 1000));
       }
       
-      // Now generate new suggested trades
-      console.log('Generating new suggested trades...');
-      const response = await portfolioApiClient.constructPortfolio({
-        portfolio_goal: portfolio.goal,
-        portfolio_id: portfolio.id,
-        user_id: portfolio.userId,
-        create_suggested_trades: true
-      });
-      
-      // Debug logging to understand the response
-      console.log('Construct portfolio response:', response);
-      
-      // Check if the response indicates success
-      // The response is successful if it has recommendations or suggested_trades_created
-      const isSuccessful = response.success === true || 
-                          response.recommendations?.length > 0 || 
-                          (response.suggested_trades_created?.count ?? 0) > 0;
-      
-      if (isSuccessful) {
-        // Real-time listener will automatically refresh the list after a successful call
-        
-        // Provide feedback about what happened
-        if (response.suggested_trades_created && response.suggested_trades_created.count > 0) {
-          // Success with trades created
-          console.log(`Successfully created ${response.suggested_trades_created.count} suggested trades`);
-        } else if (response.recommendations && response.recommendations.length > 0) {
-          // Success with recommendations but maybe no trades created yet
-          console.log(`Received ${response.recommendations.length} recommendations`);
-        } else {
-          // Success but no meaningful content
-          setError('Portfolio analysis completed but no specific trade recommendations were generated. This could be because your portfolio already aligns well with your goals.');
-        }
+      // Now generate new suggested trades asynchronously
+      console.log('Queuing new suggested trades...');
+      const response = await portfolioApiClient.requestSuggestedTrades(portfolio.id);
+      if (response.queued) {
+        console.log('Suggested trades request queued');
       } else {
-        setError(response.message || 'Failed to generate portfolio recommendations');
+        setError('Failed to queue suggested trades');
       }
     } catch (err) {
       setError(`Failed to generate suggestions: ${err instanceof Error ? err.message : 'Unknown error'}`);

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -591,6 +591,7 @@ export const subscribeSuggestedTrades = (
     let q = query(
       collection(db, 'portfolios', portfolioId, 'suggestedTrades'),
       where('userId', '==', userId),
+      where('expiresAt', '>', Timestamp.now()),
       orderBy('createdAt', 'desc')
     );
 
@@ -600,6 +601,7 @@ export const subscribeSuggestedTrades = (
         collection(db, 'portfolios', portfolioId, 'suggestedTrades'),
         where('userId', '==', userId),
         where('status', '==', status),
+        where('expiresAt', '>', Timestamp.now()),
         orderBy('createdAt', 'desc')
       );
     }
@@ -615,6 +617,7 @@ export const subscribeSuggestedTrades = (
           createdAt: data.createdAt?.toDate() || new Date(),
           updatedAt: data.updatedAt?.toDate() || new Date(),
           dismissedAt: data.dismissedAt?.toDate() || undefined,
+          expiresAt: data.expiresAt?.toDate() || undefined,
         } as SuggestedTrade);
       });
       callback(trades);

--- a/src/lib/portfolio-api-client.ts
+++ b/src/lib/portfolio-api-client.ts
@@ -7,6 +7,7 @@ const GET_SUGGESTED_TRADES_URL = 'https://get-suggested-trades-32rtfol3iq-uc.a.r
 const CONVERT_SUGGESTED_TRADE_URL = 'https://convert-suggested-trade-32rtfol3iq-uc.a.run.app';
 const DISMISS_SUGGESTED_TRADE_URL = 'https://dismiss-suggested-trade-32rtfol3iq-uc.a.run.app';
 const REQUEST_PORTFOLIO_PERFORMANCE_URL = 'https://request-portfolio-performance-32rtfol3iq-uc.a.run.app';
+const REQUEST_SUGGESTED_TRADES_URL = 'https://request-suggested-trades-32rtfol3iq-uc.a.run.app';
 
 export interface ConstructPortfolioRequest {
   portfolio_goal: string;
@@ -59,6 +60,13 @@ export interface DismissSuggestedTradeResponse {
 export interface RequestPortfolioPerformanceResponse {
   queued: boolean;
   portfolio_id: string;
+  timestamp: string;
+}
+
+export interface RequestSuggestedTradesResponse {
+  queued: boolean;
+  portfolio_id: string;
+  user_id: string;
   timestamp: string;
 }
 
@@ -239,6 +247,36 @@ export class PortfolioApiClient {
       return data as RequestPortfolioPerformanceResponse;
     } catch (error) {
       console.error('Error requesting portfolio advice:', error);
+      throw error;
+    }
+  }
+
+  async requestSuggestedTrades(portfolioId: string): Promise<RequestSuggestedTradesResponse> {
+    try {
+      const token = await this.getAuthToken();
+      const user = auth.currentUser;
+      if (!user) {
+        throw new Error('User not authenticated');
+      }
+
+      const response = await fetch(REQUEST_SUGGESTED_TRADES_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ portfolio_id: portfolioId, user_id: user.uid })
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || 'Failed to request suggested trades');
+      }
+
+      return data as RequestSuggestedTradesResponse;
+    } catch (error) {
+      console.error('Error requesting suggested trades:', error);
       throw error;
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,6 +78,7 @@ export interface SuggestedTrade {
   convertedToTradeId?: string;
   dismissedReason?: string;
   dismissedAt?: Date;
+  expiresAt?: Date;
 }
 
 export interface PortfolioRecommendation {


### PR DESCRIPTION
## Summary
- queue creation of suggested trades via new cloud functions
- add expiration time to suggested trades
- filter expired trades when querying Firestore
- expose `requestSuggestedTrades` in the API client and use it in the UI
- monitor the collection for new trades

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ae5d48b14832eab9fe3bd7ae0096a