### PR TITLE
Add 'show less' toggle for Markdown advice

### DIFF
--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -20,9 +20,12 @@ export default function MarkdownViewer({ content, maxLines = 4 }: MarkdownViewer
       <ReactMarkdown remarkPlugins={[remarkGfm]} className="prose prose-sm">
         {displayContent}
       </ReactMarkdown>
-      {shouldTruncate && !expanded && (
-        <button onClick={() => setExpanded(true)} className="text-blue-600 mt-2 text-sm">
-          Show more
+      {shouldTruncate && (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="text-blue-600 mt-2 text-sm"
+        >
+          {expanded ? 'Show less' : 'Show more'}
         </button>
       )}
     </div>


### PR DESCRIPTION
## Summary
- enable toggling expanded advice text by showing **Show less** button when expanded

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `playwright` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b909a9148832e84eaa57966e3833f