### PR TITLE
Fix suggested trade dismissal

### DIFF
--- a/functions/portfolio_service.py
+++ b/functions/portfolio_service.py
@@ -11,6 +11,7 @@ from langchain_openai import ChatOpenAI
 from langchain.agents import create_openai_tools_agent, AgentExecutor
 from langchain.prompts import ChatPromptTemplate
 from google.cloud import firestore
+from google.cloud.firestore_v1 import FieldPath
 from firestore_utils import safe_firestore_add, safe_firestore_update, clean_string_field, clean_numeric_field, sanitize_for_firestore
 
 # Import tool modules (we'll need to copy these)
@@ -611,7 +612,7 @@ class PortfolioService:
             # Get the suggested trade from any portfolio
             query = (
                 self.db.collection_group('suggestedTrades')
-                .where(firestore.FieldPath.document_id(), '==', suggested_trade_id)
+                .where(FieldPath.document_id(), '==', suggested_trade_id)
             )
             docs = list(query.get())
             if not docs:
@@ -714,7 +715,7 @@ class PortfolioService:
             # Get the suggested trade from any portfolio
             query = (
                 self.db.collection_group('suggestedTrades')
-                .where(firestore.FieldPath.document_id(), '==', suggested_trade_id)
+                .where(FieldPath.document_id(), '==', suggested_trade_id)
             )
             docs = list(query.get())
             if not docs:


### PR DESCRIPTION
## Summary
- import `FieldPath` from the Firestore v1 client
- reference `FieldPath.document_id()` correctly when querying for suggested trades

## Testing
- `npm test` *(fails: playwright not installed)*
- `pytest` *(fails: ModuleNotFoundError: dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_687b94ade18c832e9f79dd3fad5eb630